### PR TITLE
Fixed import issue for parse_signature_blob

### DIFF
--- a/bitgo/bitgo.py
+++ b/bitgo/bitgo.py
@@ -43,7 +43,7 @@ from pycoin.tx import Spendable
 from pycoin.tx.pay_to.ScriptMultisig import ScriptMultisig
 from pycoin.tx.pay_to import SolvingError
 from pycoin.tx.script import tools
-from pycoin.tx.script.vm import parse_signature_blob
+from pycoin.tx.script.check_signature import parse_signature_blob
 from pycoin import ecdsa
 from pycoin import encoding
 


### PR DESCRIPTION
pycoin changed the location of parse_signature_blob from vm.py to check_signature.py within the same folder.

This fixes #1 .
